### PR TITLE
[Experimental] Make `STOMPPromise` non-copyable and implement `STOMPContinuation`

### DIFF
--- a/Benchmarks/Thresholds/STOMPNIOBenchmarks.STOMPConnection_Connection.p90.json
+++ b/Benchmarks/Thresholds/STOMPNIOBenchmarks.STOMPConnection_Connection.p90.json
@@ -1,5 +1,5 @@
 {
-  "cpuTotal" : 437247,
+  "cpuTotal" : 431615,
   "mallocCountTotal" : 525,
-  "peakMemoryResident" : 20185087
+  "peakMemoryResident" : 20430847
 }

--- a/Benchmarks/Thresholds/STOMPNIOBenchmarks.STOMPConnection_Send.p90.json
+++ b/Benchmarks/Thresholds/STOMPNIOBenchmarks.STOMPConnection_Send.p90.json
@@ -1,5 +1,5 @@
 {
-  "cpuTotal" : 533503,
+  "cpuTotal" : 518143,
   "mallocCountTotal" : 79,
-  "peakMemoryResident" : 20545536
+  "peakMemoryResident" : 20611071
 }

--- a/Benchmarks/Thresholds/STOMPNIOBenchmarks.STOMPConnection_Subscribe.p90.json
+++ b/Benchmarks/Thresholds/STOMPNIOBenchmarks.STOMPConnection_Subscribe.p90.json
@@ -1,5 +1,5 @@
 {
-  "cpuTotal" : 628735,
-  "mallocCountTotal" : 83,
-  "peakMemoryResident" : 20398080
+  "cpuTotal" : 579583,
+  "mallocCountTotal" : 82,
+  "peakMemoryResident" : 20480000
 }

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.36.0"),
         .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.26.0"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.2.0"),
-        .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.4"),
+        .package(url: "https://github.com/apple/swift-collections.git", from: "1.3.0"),
         .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.8.0"),
         .package(url: "https://github.com/apple/swift-configuration.git", from: "1.0.0"),
     ],
@@ -32,6 +32,7 @@ let package = Package(
             name: "STOMPNIO",
             dependencies: [
                 .target(name: "_STOMPConnectionPool"),
+                .product(name: "BasicContainers", package: "swift-collections"),
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "NIOCore", package: "swift-nio"),
                 .product(name: "NIOPosix", package: "swift-nio"),

--- a/Sources/STOMPNIO/Connection/STOMPChannelHandler+stateMachine.swift
+++ b/Sources/STOMPNIO/Connection/STOMPChannelHandler+stateMachine.swift
@@ -1,3 +1,4 @@
+import BasicContainers
 public import NIOCore
 
 extension STOMPChannelHandler {
@@ -28,38 +29,38 @@ extension STOMPChannelHandler {
         var state: State
 
         @usableFromInline
-        struct InitializedState {
+        struct InitializedState: ~Copyable {
             let context: Context
-            let connectTask: STOMPTask
+            var connectTask: STOMPTask
+            /// Cached `EventLoopPromise` from the connect task for `waitOnConnected`
+            let connectPromise: EventLoopPromise<STOMPFrame>
         }
 
         @usableFromInline
-        struct STOMPTasks {
-            var tasks: [STOMPTask]
+        struct STOMPTasks: ~Copyable {
+            var tasks: UniqueArray<STOMPTask>
 
-            init(_ tasks: [STOMPTask] = []) {
-                self.tasks = tasks
+            init() {
+                self.tasks = UniqueArray()
             }
 
-            mutating func append(_ task: STOMPTask) {
+            mutating func append(_ task: consuming STOMPTask) {
                 self.tasks.append(task)
             }
 
-            mutating func remove(at index: [STOMPTask].Index) {
+            mutating func remove(at index: UniqueArray<STOMPTask>.Index) -> STOMPTask {
                 if index == tasks.endIndex - 1 {
-                    self.tasks.removeLast()
+                    return self.tasks.removeLast()
                 } else {
-                    let lastTask = self.tasks.removeLast()
-                    self.tasks[index] = lastTask
+                    self.tasks.swapAt(index, self.tasks.endIndex - 1)
+                    return self.tasks.removeLast()
                 }
             }
 
-            mutating func removeFirst(where condition: (STOMPTask) -> Bool) -> STOMPTask? {
+            mutating func removeFirst(where condition: (borrowing STOMPTask) -> Bool) -> STOMPTask? {
                 for index in self.tasks.indices {
                     if condition(self.tasks[index]) {
-                        let task = self.tasks[index]
-                        self.remove(at: index)
-                        return task
+                        return self.remove(at: index)
                     }
                 }
                 return nil
@@ -69,40 +70,57 @@ extension STOMPChannelHandler {
                 self.tasks.isEmpty
             }
 
-            enum ProcessFrameAction {
+            var earliestDeadline: NIODeadline? {
+                var earliest: NIODeadline? = nil
+                for index in tasks.indices {
+                    let d = tasks[index].deadline
+                    if earliest == nil || d < earliest! {
+                        earliest = d
+                    }
+                }
+                return earliest
+            }
+
+            var deadlineCallbackAction: DeadlineCallbackAction {
+                if self.isEmpty {
+                    return .cancel
+                } else if let earliest = self.earliestDeadline {
+                    return .reschedule(earliest)
+                } else {
+                    return .doNothing
+                }
+            }
+
+            enum ProcessFrameAction: ~Copyable {
                 case succeedTask(STOMPTask, DeadlineCallbackAction)
                 case failTask(STOMPTask, any Error)
                 case unhandledTask
             }
             mutating func processFrame(_ frame: STOMPFrame) -> ProcessFrameAction {
-                for (index, task) in self.tasks.enumerated() {
+                for index in self.tasks.indices {
                     do {
                         // should this task respond to inbound frame
-                        if try task.checkInbound(frame) {
-                            self.remove(at: index)
-                            let deadlineCallback: DeadlineCallbackAction =
-                                if self.tasks.isEmpty {
-                                    .cancel
-                                } else {
-                                    if let earliestDeadline = self.tasks.map({ $0.deadline }).min() {
-                                        .reschedule(earliestDeadline)
-                                    } else {
-                                        .doNothing
-                                    }
-                                }
-                            return .succeedTask(task, deadlineCallback)
+                        if try self.tasks[index].checkInbound(frame) {
+                            let task = self.remove(at: index)
+                            return .succeedTask(task, self.deadlineCallbackAction)
                         }
                     } catch {
-                        self.remove(at: index)
+                        let task = self.remove(at: index)
                         return .failTask(task, error)
                     }
                 }
                 return .unhandledTask
             }
+
+            mutating func failAll(_ error: any Error) {
+                while !self.tasks.isEmpty {
+                    self.tasks.removeLast().fail(error)
+                }
+            }
         }
 
         @usableFromInline
-        struct ConnectedState {
+        struct ConnectedState: ~Copyable {
             let context: Context
             var tasks: STOMPTasks
 
@@ -123,10 +141,10 @@ extension STOMPChannelHandler {
 
         /// handler has become active
         @usableFromInline
-        mutating func setInitialized(context: Context, connectTask: STOMPTask) {
+        mutating func setInitialized(context: Context, connectTask: consuming STOMPTask, connectPromise: EventLoopPromise<STOMPFrame>) {
             switch consume self.state {
             case .uninitialized:
-                self = .initialized(.init(context: context, connectTask: connectTask))
+                self = .initialized(.init(context: context, connectTask: connectTask, connectPromise: connectPromise))
             case .initialized:
                 preconditionFailure("Cannot set initialized state when state is initialized")
             case .connected:
@@ -139,14 +157,14 @@ extension STOMPChannelHandler {
         }
 
         @usableFromInline
-        enum SendFrameAction {
+        enum SendFrameAction: ~Copyable {
             case sendFrame(Context)
-            case throwError(any Error)
+            case throwError(any Error, STOMPTask?)
         }
 
         /// handler wants to send a frame
         @usableFromInline
-        mutating func sendFrame(_ task: STOMPTask?) -> SendFrameAction {
+        mutating func sendFrame(_ task: consuming STOMPTask?) -> SendFrameAction {
             switch consume self.state {
             case .uninitialized:
                 preconditionFailure("Cannot send frame when uninitialized")
@@ -156,14 +174,15 @@ extension STOMPChannelHandler {
                 if let task {
                     state.tasks.append(task)
                 }
+                let context = state.context
                 self = .connected(state)
-                return .sendFrame(state.context)
+                return .sendFrame(context)
             case .closing(let state):
                 self = .closing(state)
-                return .throwError(STOMPClientError.connectionClosing)
+                return .throwError(STOMPClientError.connectionClosing, task)
             case .closed(let error):
                 self = .closed(error)
-                return .throwError(STOMPClientError.connectionClosed)
+                return .throwError(STOMPClientError.connectionClosed, task)
             }
         }
 
@@ -175,7 +194,7 @@ extension STOMPChannelHandler {
         }
 
         @usableFromInline
-        enum ReceivedFrameAction {
+        enum ReceivedFrameAction: ~Copyable {
             case messageReceived
             case succeedTask(STOMPTask, DeadlineCallbackAction)
             case failTask(STOMPTask, any Error)
@@ -191,8 +210,10 @@ extension STOMPChannelHandler {
             case .initialized(let state):
                 switch frame.command {
                 case .connected:
-                    self = .connected(.init(context: state.context, tasks: .init()))
-                    return .succeedTask(state.connectTask, .cancel)
+                    let context = state.context
+                    let connectTask = state.connectTask
+                    self = .connected(.init(context: context, tasks: .init()))
+                    return .succeedTask(connectTask, .cancel)
                 case .error:
                     let error = STOMPClientError.errorFrame(
                         message: frame.headers[.message],
@@ -213,7 +234,7 @@ extension STOMPChannelHandler {
                 case .receipt:
                     let action = state.tasks.processFrame(frame)
                     self = .connected(state)
-                    switch action {
+                    switch consume action {
                     case .succeedTask(let task, let deadlineCallback):
                         return .succeedTask(task, deadlineCallback)
                     case .failTask(let task, let error):
@@ -242,26 +263,21 @@ extension STOMPChannelHandler {
                     self = .closing(state)
                     return .messageReceived
                 case .receipt:
-                    for (index, task) in state.tasks.tasks.enumerated() {
+                    for index in state.tasks.tasks.indices {
                         do {
-                            if try task.checkInbound(frame) {
-                                state.tasks.remove(at: index)
+                            if try state.tasks.tasks[index].checkInbound(frame) {
+                                let task = state.tasks.remove(at: index)
                                 if state.tasks.isEmpty {
                                     self = .closed(nil)
                                     return .succeedTask(task, .cancel)
                                 } else {
+                                    let deadlineCallback = state.tasks.deadlineCallbackAction
                                     self = .closing(state)
-                                    let deadlineCallback: DeadlineCallbackAction =
-                                        if let earliestDeadline = state.tasks.tasks.map({ $0.deadline }).min() {
-                                            .reschedule(earliestDeadline)
-                                        } else {
-                                            .doNothing
-                                        }
                                     return .succeedTask(task, deadlineCallback)
                                 }
                             }
                         } catch {
-                            state.tasks.remove(at: index)
+                            let task = state.tasks.remove(at: index)
                             if state.tasks.isEmpty {
                                 self = .closed(nil)
                                 return .failTask(task, error)
@@ -306,13 +322,9 @@ extension STOMPChannelHandler {
             case .uninitialized:
                 preconditionFailure("Cannot wait until connection has succeeded")
             case .initialized(let state):
-                switch state.connectTask.promise {
-                case .nio(let promise):
-                    self = .initialized(state)
-                    return .waitForPromise(promise)
-                case .swift, .forget:
-                    preconditionFailure("Initialized state cannot be setup with a Swift continuation")
-                }
+                let promise = state.connectPromise
+                self = .initialized(state)
+                return .waitForPromise(promise)
             case .connected(let state):
                 self = .connected(state)
                 return .done
@@ -326,8 +338,8 @@ extension STOMPChannelHandler {
         }
 
         @usableFromInline
-        enum HitDeadlineAction {
-            case failTasksAndClose(Context, [STOMPTask])
+        enum HitDeadlineAction: ~Copyable {
+            case failTasksAndClose(Context, STOMPTasks)
             case reschedule(NIODeadline)
             case clearCallback
         }
@@ -338,18 +350,24 @@ extension STOMPChannelHandler {
             case .uninitialized:
                 preconditionFailure("Cannot cancel when uninitialized")
             case .initialized(let state):
-                if state.connectTask.deadline <= now {
+                let deadline = state.connectTask.deadline
+                if deadline <= now {
+                    let context = state.context
+                    var tasks = STOMPTasks()
+                    tasks.append(state.connectTask)
                     self = .closed(STOMPClientError.timeout)
-                    return .failTasksAndClose(state.context, [state.connectTask])
+                    return .failTasksAndClose(context, tasks)
                 } else {
                     self = .initialized(state)
-                    return .reschedule(state.connectTask.deadline)
+                    return .reschedule(deadline)
                 }
             case .connected(let state):
-                if let earliestDeadline = state.tasks.tasks.map({ $0.deadline }).min() {
+                if let earliestDeadline = state.tasks.earliestDeadline {
                     if earliestDeadline <= now {
+                        let context = state.context
+                        let tasks = state.tasks
                         self = .closed(STOMPClientError.timeout)
-                        return .failTasksAndClose(state.context, state.tasks.tasks)
+                        return .failTasksAndClose(context, tasks)
                     } else {
                         self = .connected(state)
                         return .reschedule(earliestDeadline)
@@ -362,10 +380,12 @@ extension STOMPChannelHandler {
                 guard !state.tasks.isEmpty else {
                     preconditionFailure("Cannot be in closing state with no active tasks")
                 }
-                if let earliestDeadline = state.tasks.tasks.map({ $0.deadline }).min() {
+                if let earliestDeadline = state.tasks.earliestDeadline {
                     if earliestDeadline <= now {
+                        let context = state.context
+                        let tasks = state.tasks
                         self = .closed(STOMPClientError.timeout)
-                        return .failTasksAndClose(state.context, state.tasks.tasks)
+                        return .failTasksAndClose(context, tasks)
                     } else {
                         self = .closing(state)
                         return .reschedule(earliestDeadline)
@@ -381,7 +401,7 @@ extension STOMPChannelHandler {
         }
 
         @usableFromInline
-        enum CancelAction {
+        enum CancelAction: ~Copyable {
             case failTask(STOMPTask)
             case doNothing
         }
@@ -429,11 +449,15 @@ extension STOMPChannelHandler {
                 self = .closed(nil)
                 return .doNothing
             case .initialized(let state):
-                self = .closing(.init(context: state.context, tasks: .init([state.connectTask])))
+                let context = state.context
+                var tasks = STOMPTasks()
+                tasks.append(state.connectTask)
+                self = .closing(.init(context: context, tasks: tasks))
                 return .doNothing
             case .connected(let state):
                 if !state.tasks.isEmpty {
-                    self = .closing(.init(context: state.context, tasks: state.tasks))
+                    let tasks = state.tasks
+                    self = .closing(.init(context: state.context, tasks: tasks))
                     return .doNothing
                 } else {
                     self = .closed(nil)
@@ -449,9 +473,9 @@ extension STOMPChannelHandler {
         }
 
         @usableFromInline
-        enum CloseAction {
+        enum CloseAction: ~Copyable {
             case doNothing
-            case failTasksAndClose([STOMPTask])
+            case failTasksAndClose(STOMPTasks)
         }
 
         /// Want to close the connection
@@ -463,13 +487,15 @@ extension STOMPChannelHandler {
                 return .doNothing
             case .initialized(let state):
                 self = .closed(nil)
-                return .failTasksAndClose([state.connectTask])
+                var tasks = STOMPTasks()
+                tasks.append(state.connectTask)
+                return .failTasksAndClose(tasks)
             case .connected(let state):
                 self = .closed(nil)
-                return .failTasksAndClose(state.tasks.tasks)
+                return .failTasksAndClose(state.tasks)
             case .closing(let state):
                 self = .closed(nil)
-                return .failTasksAndClose(state.tasks.tasks)
+                return .failTasksAndClose(state.tasks)
             case .closed(let error):
                 self = .closed(error)
                 return .doNothing
@@ -490,11 +516,13 @@ extension STOMPChannelHandler {
             case .initialized:
                 preconditionFailure("Cannot schedule heart-beat when in initialized state")
             case .connected(let state):
+                let context = state.context
                 self = .connected(state)
-                return .schedule(state.context)
+                return .schedule(context)
             case .closing(let state):
+                let context = state.context
                 self = .closing(state)
-                return .schedule(state.context)
+                return .schedule(context)
             case .closed(let error):
                 self = .closed(error)
                 return .doNothing
@@ -505,15 +533,15 @@ extension STOMPChannelHandler {
             StateMachine(.uninitialized)
         }
 
-        private static func initialized(_ state: InitializedState) -> Self {
+        private static func initialized(_ state: consuming InitializedState) -> Self {
             StateMachine(.initialized(state))
         }
 
-        private static func connected(_ state: ConnectedState) -> Self {
+        private static func connected(_ state: consuming ConnectedState) -> Self {
             StateMachine(.connected(state))
         }
 
-        private static func closing(_ state: ConnectedState) -> Self {
+        private static func closing(_ state: consuming ConnectedState) -> Self {
             StateMachine(.closing(state))
         }
 

--- a/Sources/STOMPNIO/Connection/STOMPChannelHandler.swift
+++ b/Sources/STOMPNIO/Connection/STOMPChannelHandler.swift
@@ -31,11 +31,9 @@ final class STOMPChannelHandler: ChannelDuplexHandler {
         func handleScheduledCallback(eventLoop: some NIOCore.EventLoop) {
             let channelHandler = self.channelHandler.value
             switch channelHandler.stateMachine.hitDeadline(now: .now()) {
-            case .failTasksAndClose(let context, let commands):
+            case .failTasksAndClose(let context, var tasks):
                 let error = STOMPClientError.timeout
-                for command in commands {
-                    command.promise.fail(error)
-                }
+                tasks.failAll(error)
                 channelHandler.failTasksAndCloseSubscriptions(with: error)
                 context.fireErrorCaught(error)
                 context.close(promise: nil)
@@ -118,7 +116,8 @@ final class STOMPChannelHandler: ChannelDuplexHandler {
 
         self.stateMachine.setInitialized(
             context: context,
-            connectTask: .init(promise: .nio(promise), requestID: 0, deadline: deadline) { $0.command == .connected }
+            connectTask: .init(promise: .nio(promise), requestID: 0, deadline: deadline) { $0.command == .connected },
+            connectPromise: promise
         )
     }
 
@@ -198,7 +197,7 @@ final class STOMPChannelHandler: ChannelDuplexHandler {
         self.eventLoop.assertInEventLoop()
         switch self.stateMachine.cancel(requestID: requestID) {
         case .failTask(let cancelledTask):
-            cancelledTask.promise.fail(STOMPClientError.cancelledTask)
+            cancelledTask.fail(STOMPClientError.cancelledTask)
         case .doNothing:
             break
         }
@@ -227,9 +226,9 @@ final class STOMPChannelHandler: ChannelDuplexHandler {
                 }
             }
             self.processDeadlineCallbackAction(action: deadlineAction)
-            task.promise.succeed(frame)
+            task.succeed(frame)
         case .failTask(let task, let error):
-            task.promise.fail(error)
+            task.fail(error)
         case .unhandledTask:
             break
         case .messageReceived:
@@ -291,10 +290,8 @@ final class STOMPChannelHandler: ChannelDuplexHandler {
 
     private func failTasksAndCloseSubscriptions(with error: any Error) {
         switch self.stateMachine.close() {
-        case .failTasksAndClose(let tasks):
-            for task in tasks {
-                task.promise.fail(error)
-            }
+        case .failTasksAndClose(var tasks):
+            tasks.failAll(error)
             self.subscriptions.close(error: error)
             self.deadlineCallback?.cancel()
         case .doNothing:
@@ -317,7 +314,7 @@ final class STOMPChannelHandler: ChannelDuplexHandler {
         switch self.stateMachine.sendFrame(nil) {
         case .sendFrame(let context):
             _ = context.channel.writeAndFlush(frame)
-        case .throwError(let error):
+        case .throwError(let error, _):
             throw error
         }
     }
@@ -325,7 +322,7 @@ final class STOMPChannelHandler: ChannelDuplexHandler {
     @usableFromInline
     func sendFrame(
         _ frame: STOMPFrame,
-        promise: STOMPPromise<STOMPFrame>,
+        promise: consuming STOMPPromise<STOMPFrame>,
         requestID: Int,
         checkInbound: @escaping @Sendable (STOMPFrame) throws -> Bool
     ) {
@@ -338,8 +335,8 @@ final class STOMPChannelHandler: ChannelDuplexHandler {
             if self.deadlineCallback == nil {
                 self.scheduleDeadlineCallback(deadline: deadline)
             }
-        case .throwError(let error):
-            task.promise.fail(error)
+        case .throwError(let error, let task):
+            task?.fail(error)
         }
     }
 
@@ -359,7 +356,7 @@ final class STOMPChannelHandler: ChannelDuplexHandler {
         ackMode: STOMPSubscription.AckMode,
         userDefinedHeaders: STOMPHeaders,
         transactionID: String?,
-        promise: STOMPPromise<UInt>,
+        continuation: CheckedContinuation<UInt, any Error>,
         requestID: Int
     ) {
         self.eventLoop.assertInEventLoop()
@@ -385,10 +382,10 @@ final class STOMPChannelHandler: ChannelDuplexHandler {
         }.assumeIsolated().whenComplete { result in
             switch result {
             case .success:
-                promise.succeed(subscriptionID)
+                continuation.resume(returning: subscriptionID)
             case .failure(let error):
                 self.subscriptions.removeSubscription(id: subscriptionID)
-                promise.fail(error)
+                continuation.resume(throwing: error)
             }
         }
     }
@@ -396,7 +393,7 @@ final class STOMPChannelHandler: ChannelDuplexHandler {
     func unsubscribe(
         id: UInt,
         userDefinedHeaders: STOMPHeaders,
-        promise: STOMPPromise<Void>,
+        continuation: CheckedContinuation<Void, any Error>,
         requestID: Int
     ) {
         self.eventLoop.assertInEventLoop()
@@ -414,9 +411,9 @@ final class STOMPChannelHandler: ChannelDuplexHandler {
         }.assumeIsolated().whenComplete { result in
             switch result {
             case .success:
-                promise.succeed(())
+                continuation.resume(returning: ())
             case .failure(let error):
-                promise.fail(error)
+                continuation.resume(throwing: error)
             }
         }
     }
@@ -470,7 +467,7 @@ final class STOMPChannelHandler: ChannelDuplexHandler {
             var buffer = context.channel.allocator.buffer(capacity: 1)
             buffer.writeString("\n")
             _ = context.writeAndFlush(self.wrapOutboundOut(buffer))
-        case .throwError(let error):
+        case .throwError(let error, _):
             throw error
         }
     }

--- a/Sources/STOMPNIO/Connection/STOMPConnection.swift
+++ b/Sources/STOMPNIO/Connection/STOMPConnection.swift
@@ -498,7 +498,7 @@ public final actor STOMPConnection: Sendable {
             if Task.isCancelled {
                 throw STOMPClientError.cancelledTask
             }
-            return try await withCheckedThrowingContinuation { continuation in
+            return try await withSTOMPThrowingContinuation { continuation in
                 self.channelHandler.sendFrame(frame, promise: .swift(continuation), requestID: requestID, checkInbound: checkInbound)
             }
         } onCancel: {

--- a/Sources/STOMPNIO/Connection/STOMPContinuation.swift
+++ b/Sources/STOMPNIO/Connection/STOMPContinuation.swift
@@ -9,6 +9,7 @@ struct STOMPContinuation<Success, Failure: Error>: ~Copyable, Sendable {
         self.unsafeContinuation = unsafeContinuation
     }
 
+    @inlinable
     deinit {
         fatalError("This continuation was dropped.")
     }

--- a/Sources/STOMPNIO/Connection/STOMPContinuation.swift
+++ b/Sources/STOMPNIO/Connection/STOMPContinuation.swift
@@ -1,0 +1,53 @@
+/// A `~Copyable` continuation wrapper around `UnsafeContinuation` that enforces exactly-once fulfillment at compile time.
+@usableFromInline
+struct STOMPContinuation<Success, Failure: Error>: ~Copyable, Sendable {
+    @usableFromInline
+    let unsafeContinuation: UnsafeContinuation<Success, Failure>
+
+    @inlinable
+    init(_ unsafeContinuation: UnsafeContinuation<Success, Failure>) {
+        self.unsafeContinuation = unsafeContinuation
+    }
+
+    deinit {
+        fatalError("This continuation was dropped.")
+    }
+
+    @inlinable
+    consuming func resume(returning value: sending Success) where Failure == Never {
+        self.unsafeContinuation.resume(returning: value)
+        discard self
+    }
+
+    @inlinable
+    consuming func resume(returning value: sending Success) {
+        self.unsafeContinuation.resume(returning: value)
+        discard self
+    }
+
+    @inlinable
+    consuming func resume(throwing error: consuming Failure) {
+        self.unsafeContinuation.resume(throwing: error)
+        discard self
+    }
+}
+
+@inlinable
+func withSTOMPContinuation<Success>(
+    of: Success.Type = Success.self,
+    _ body: (consuming STOMPContinuation<Success, Never>) -> Void
+) async -> Success {
+    await withUnsafeContinuation { continuation in
+        body(STOMPContinuation(continuation))
+    }
+}
+
+@inlinable
+func withSTOMPThrowingContinuation<Success>(
+    of: Success.Type = Success.self,
+    _ body: (consuming STOMPContinuation<Success, any Error>) -> Void
+) async throws -> Success {
+    try await withUnsafeThrowingContinuation { continuation in
+        body(STOMPContinuation(continuation))
+    }
+}

--- a/Sources/STOMPNIO/Connection/STOMPTask.swift
+++ b/Sources/STOMPNIO/Connection/STOMPTask.swift
@@ -1,28 +1,30 @@
 public import NIOCore
 
 @usableFromInline
-enum STOMPPromise<T: Sendable>: Sendable {
+enum STOMPPromise<T: Sendable>: ~Copyable, Sendable {
     case nio(EventLoopPromise<T>)
-    case swift(CheckedContinuation<T, any Error>)
+    case swift(STOMPContinuation<T, any Error>)
     case forget
 
-    func succeed(_ t: T) {
-        switch self {
+    @usableFromInline
+    consuming func succeed(_ t: T) {
+        switch consume self {
         case .nio(let eventLoopPromise):
             eventLoopPromise.succeed(t)
-        case .swift(let checkedContinuation):
-            checkedContinuation.resume(returning: t)
+        case .swift(let stompContinuation):
+            stompContinuation.resume(returning: t)
         case .forget:
             break
         }
     }
 
-    func fail(_ error: any Error) {
-        switch self {
+    @usableFromInline
+    consuming func fail(_ error: any Error) {
+        switch consume self {
         case .nio(let eventLoopPromise):
             eventLoopPromise.fail(error)
-        case .swift(let checkedContinuation):
-            checkedContinuation.resume(throwing: error)
+        case .swift(let stompContinuation):
+            stompContinuation.resume(throwing: error)
         case .forget:
             break
         }
@@ -30,14 +32,15 @@ enum STOMPPromise<T: Sendable>: Sendable {
 }
 
 @usableFromInline
-final class STOMPTask: Sendable {
+struct STOMPTask: ~Copyable, Sendable {
     let promise: STOMPPromise<STOMPFrame>
     let checkInbound: @Sendable (STOMPFrame) throws -> Bool
     let requestID: Int
     let deadline: NIODeadline
 
+    @usableFromInline
     init(
-        promise: STOMPPromise<STOMPFrame>,
+        promise: consuming STOMPPromise<STOMPFrame>,
         requestID: Int,
         deadline: NIODeadline,
         checkInbound: @escaping @Sendable (STOMPFrame) throws -> Bool
@@ -46,5 +49,15 @@ final class STOMPTask: Sendable {
         self.checkInbound = checkInbound
         self.requestID = requestID
         self.deadline = deadline
+    }
+
+    @usableFromInline
+    consuming func succeed(_ frame: STOMPFrame) {
+        promise.succeed(frame)
+    }
+
+    @usableFromInline
+    consuming func fail(_ error: any Error) {
+        promise.fail(error)
     }
 }

--- a/Sources/STOMPNIO/Subscriptions/STOMPConnection+subscribe.swift
+++ b/Sources/STOMPNIO/Subscriptions/STOMPConnection+subscribe.swift
@@ -60,7 +60,7 @@ extension STOMPConnection {
                 ackMode: ackMode,
                 userDefinedHeaders: userDefinedHeaders,
                 transactionID: transactionID,
-                promise: .swift(continuation),
+                continuation: continuation,
                 requestID: Self.requestIDGenerator.next()
             )
         }
@@ -73,7 +73,7 @@ extension STOMPConnection {
             self.channelHandler.unsubscribe(
                 id: id,
                 userDefinedHeaders: userDefinedHeaders,
-                promise: .swift(continuation),
+                continuation: continuation,
                 requestID: Self.requestIDGenerator.next()
             )
         }

--- a/Tests/STOMPNIOTests/STOMPContinuationTests.swift
+++ b/Tests/STOMPNIOTests/STOMPContinuationTests.swift
@@ -1,0 +1,68 @@
+import Testing
+
+@testable import STOMPNIO
+
+@Suite("STOMPContinuation Tests")
+struct STOMPContinuationTests {
+    @Test("Resume Continuation with Value")
+    func resumeContinuationWithValue() async {
+        let result = await withSTOMPContinuation { continuation in
+            continuation.resume(returning: "hello")
+        }
+        #expect(result == "hello")
+    }
+
+    @Test("Resume Continuation with Void")
+    func resumeContinuationWithVoid() async {
+        await withSTOMPContinuation { continuation in
+            continuation.resume(returning: ())
+        }
+    }
+
+    @Test("Resume Throwing Continuation with Value")
+    func resumeThrowingContinuationWithValue() async throws {
+        let result = try await withSTOMPThrowingContinuation { continuation in
+            continuation.resume(returning: "world")
+        }
+        #expect(result == "world")
+    }
+
+    @Test("Resume Throwing Continuation with Void")
+    func resumeThrowingContinuationWithVoid() async throws {
+        try await withSTOMPThrowingContinuation { continuation in
+            continuation.resume(returning: ())
+        }
+    }
+
+    @Test("Resume Throwing Continuation with Error")
+    func resumeThrowingContinuationWithError() async {
+        await #expect(throws: TestError.self) {
+            let _: Int = try await withSTOMPThrowingContinuation { continuation in
+                continuation.resume(throwing: TestError())
+            }
+        }
+    }
+
+    @Test("Succeed STOMPPromise")
+    func succeedSTOMPPromise() async throws {
+        let frame = STOMPFrame(command: .message, headers: [.destination: "/test"])
+        let result: STOMPFrame = try await withSTOMPThrowingContinuation { continuation in
+            let promise: STOMPPromise<STOMPFrame> = .swift(continuation)
+            promise.succeed(frame)
+        }
+        #expect(result.command == .message)
+        #expect(result.headers[.destination] == "/test")
+    }
+
+    @Test("Fail STOMPPromise")
+    func failSTOMPPromise() async {
+        await #expect(throws: TestError.self) {
+            let _: STOMPFrame = try await withSTOMPThrowingContinuation { continuation in
+                let promise: STOMPPromise<STOMPFrame> = .swift(continuation)
+                promise.fail(TestError())
+            }
+        }
+    }
+
+    private struct TestError: Error {}
+}


### PR DESCRIPTION
This is an experimental attempt to make `STOMPPromise` a non-copyable type.
This way, its `.swift` promise can be changed from `CheckedContinuation` to `UnsafeContinuation` (or rather `STOMPContinuation`, a wrapper around it), since the compiler enforces that the continuation is resumed no more than once.

`STOMPTask` has also been made non-copyable.
The channel handler's state machine now stores `STOMPTask`s in a `UniqueArray` from `swift-collections`.

The `subscribe` and `unsubscribe` methods of `STOMPChannelHandler` have to use a `CheckedContinuation` because the non-copyable `STOMPPromise` cannot be captured by `@escaping` closures.

The promise of `InitializedState`'s `connectTask` must be cached due to a potential compiler bug.

Original idea by @fabianfett