### PR TITLE
Subscription connection manager

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
       matrix:
         tag:
           - swift:6.2
+          - swift:6.3
     container:
       image: ${{ matrix.tag }}
     services:

--- a/Package.swift
+++ b/Package.swift
@@ -56,7 +56,8 @@ let package = Package(
         .testTarget(
             name: "STOMPNIOTests",
             dependencies: [
-                .target(name: "STOMPNIO")
+                .target(name: "STOMPNIO"),
+                .product(name: "NIOFoundationCompat", package: "swift-nio"),
             ],
             swiftSettings: swiftSettings
         ),

--- a/README.md
+++ b/README.md
@@ -23,17 +23,55 @@ STOMPNIO is a Swift NIO based implementation of a STOMP client. It supports:
 
 ## Overview
 
-The STOMP NIO project uses a connection pool, which requires a background process to manage it.
-You can either run it using a `TaskGroup` or `async let`.
-Below we are using `async let` to run the connection pool background process.
+Create a client with server connection details:
+
+```swift
+import STOMPNIO
+
+let stompClient = STOMPClient(.hostname("localhost"), logger: logger)
+```
+
+The `STOMPClient` uses a connection pool, which requires a background process to manage it.
+
+You can run the background process using `async let`. When you leave the scope of the function your `async let` variable is declared the client will be shutdown.
 
 ```swift
 let stompClient = STOMPClient(.hostname("localhost"), logger: logger)
 async let _ = stompClient.run()
-// use STOMP client
+
+// Use STOMP client
+try await stompClient.send("Hello, World!", to: "/queue/a")
+// Client continues running in background
 ```
 
-Or you can use `STOMPClient` with [`swift-service-lifecycle`](https://github.com/swift-server/swift-service-lifecycle).
+Alternatively you could also use a `TaskGroup`.
+
+```swift
+try await withThrowingTaskGroup { group in
+    group.addTask {
+        await stompClient.run()
+    }
+
+    // All operations happen in the closure body
+    try await stompClient.send("Hello, World!", to: "/queue/a")
+
+    // When done, cancel the run() task
+    group.cancelAll()
+}
+// Client is shut down when task group exits
+```
+
+Or you can use `STOMPClient` with [`swift-service-lifecycle`](https://github.com/swift-server/swift-service-lifecycle) for long-running services.
+
+```swift
+let services: [Service] = [myApp, stompClient]
+let serviceGroup = ServiceGroup(
+    services: services,
+    gracefulShutdownSignals: [.sigint, .sigterm],
+    logger: logger
+)
+try await serviceGroup.run()
+```
 
 Once you have a STOMP client setup and running you can send STOMP frames directly from the `STOMPClient`.
 
@@ -44,11 +82,9 @@ try await stompClient.send("Hello, STOMP over NIO!", to: "/queue/a")
 Or you can create a connection and subscribe to destinations from that connection using `STOMPClient.withConnection()`.
 
 ```swift
-try await stompClient.withConnection { connection in
-    try await connection.subscribe(to: "/queue/a") { subscription in
-        for try await frame in subscription {
-            print(String(buffer: frame.body))
-        }
+try await stompClient.subscribe(to: "/queue/a") { subscription in
+    for try await frame in subscription {
+        print(String(buffer: frame.body))
     }
 }
 ```

--- a/Sources/STOMPNIO/Client/STOMPClient.swift
+++ b/Sources/STOMPNIO/Client/STOMPClient.swift
@@ -21,6 +21,14 @@ public final class STOMPClient: Sendable {
         ContinuousClock
     >
 
+    @usableFromInline
+    typealias ConnectionStateMachine =
+        SubscriptionConnectionStateMachine<
+            STOMPConnection,
+            CheckedContinuation<STOMPConnection, any Error>,
+            CheckedContinuation<Void, Never>
+        >
+
     /// Connection pool
     let connectionPool: Pool
     /// Connection factory
@@ -31,6 +39,17 @@ public final class STOMPClient: Sendable {
     let logger: Logger
     /// Running atomic
     let runningAtomic: Atomic<Bool>
+
+    /// Subscription connection state
+    let subscriptionConnectionStateMachine: Mutex<ConnectionStateMachine>
+    @usableFromInline
+    let subscriptionConnectionIDGenerator: ConnectionIDGenerator
+    /// Actions that can be run on a node
+    enum RunAction: Sendable {
+        case leaseSubscriptionConnection(leaseID: Int)
+    }
+    let actionStream: AsyncStream<RunAction>
+    let actionStreamContinuation: AsyncStream<RunAction>.Continuation
 
     /// Creates a new ``STOMPClient``. Don't forget to run ``STOMPClient/run()`` the client in a long running task.
     ///
@@ -93,6 +112,9 @@ public final class STOMPClient: Sendable {
         self.eventLoopGroup = eventLoopGroup
         self.logger = logger
         self.runningAtomic = .init(false)
+        self.subscriptionConnectionStateMachine = .init(.init())
+        self.subscriptionConnectionIDGenerator = .init()
+        (self.actionStream, self.actionStreamContinuation) = AsyncStream.makeStream(of: RunAction.self)
     }
 }
 
@@ -116,11 +138,26 @@ extension STOMPClient {
         precondition(!atomicOp.original, "STOMPClient.run() should just be called once!")
         #if ServiceLifecycle
         await cancelWhenGracefulShutdown {
-            await self.connectionPool.run()
+            await self._withTaskGroup()
         }
         #else
-        await self.connectionPool.run()
+        await self._withTaskGroup()
         #endif
+    }
+
+    /// Run discarding task group running actions
+    private func _withTaskGroup() async {
+        await withDiscardingTaskGroup { group in
+            group.addTask {
+                await self.connectionPool.run()
+                self.shutdownSubscriptionConnection()
+            }
+            for await action in self.actionStream {
+                group.addTask {
+                    await self.runAction(action)
+                }
+            }
+        }
     }
 
     /// Get a connection from connection pool and run operation using it.
@@ -217,6 +254,27 @@ extension STOMPClient {
     public func heartBeat() async throws {
         try await self.withConnection { connection in
             try await connection.heartBeat()
+        }
+    }
+}
+
+extension STOMPClient {
+    func queueAction(_ action: RunAction) {
+        self.actionStreamContinuation.yield(action)
+    }
+
+    private func runAction(_ action: RunAction) async {
+        switch action {
+        case .leaseSubscriptionConnection(let leaseID):
+            do {
+                try await self.withConnection { connection in
+                    await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+                        self.acquiredSubscriptionConnection(leaseID: leaseID, connection: connection, releaseContinuation: cont)
+                    }
+                }
+            } catch {
+                self.errorAcquiringSubscriptionConnection(leaseID: leaseID, error: error)
+            }
         }
     }
 }

--- a/Sources/STOMPNIO/STOMPNIO.docc/GettingStarted.md
+++ b/Sources/STOMPNIO/STOMPNIO.docc/GettingStarted.md
@@ -11,13 +11,13 @@ Add STOMP NIO as a dependency to your project and targets that use it.
 You can use the `add-dependency` command:
 
 ```bash
-swift package add-dependency https://github.com/fpseverino/stomp-nio --from: 0.0.5
+swift package add-dependency https://github.com/fpseverino/stomp-nio --from: 0.0.6
 ```
 
 or edit Package.swift directly:
 ```swift
 dependencies: [
-    .package(url: "https://github.com/fpseverino/stomp-nio.git", from: "0.0.5"),
+    .package(url: "https://github.com/fpseverino/stomp-nio.git", from: "0.0.6"),
 ]
 ```
 
@@ -91,11 +91,9 @@ try await stompClient.send("Hello, STOMP over NIO!", to: "/queue/a")
 You can ask for a single connection and subscribe to destinations using it:
 
 ```swift
-try await stompClient.withConnection { connection in
-    try await connection.subscribe(to: "/queue/a") { subscription in
-        for try await frame in subscription {
-            print(String(buffer: frame.body))
-        }
+try await stompClient.subscribe(to: "/queue/a") { subscription in
+    for try await frame in subscription {
+        print(String(buffer: frame.body))
     }
 }
 ```

--- a/Sources/STOMPNIO/STOMPNIO.docc/Transactions-article.md
+++ b/Sources/STOMPNIO/STOMPNIO.docc/Transactions-article.md
@@ -30,7 +30,7 @@ try await STOMPConnection.withConnection(address: .hostname("localhost"), logger
 ```
 
 ```swift
-try await STOMPConnection.withConnection(address: .hostname("localhost"), logger: logger) { connection in
+try await stompClient.withConnection { connection in
     try await connection.withTransaction { transaction in
         try await transaction.subscribe(to: "/queue/a") { subscription in
             for try await frame in subscription {
@@ -71,7 +71,7 @@ If you want to abort the transaction instead, you can throw an error from the cl
 ```swift
 struct AbortTransaction: Error {}
 
-try await STOMPConnection.withConnection(address: .hostname("localhost"), logger: logger) { connection in
+try await stompClient.withConnection { connection in
     try await connection.withTransaction { transaction in
         try await transaction.send("Message in Transaction", to: "/queue/a")
         throw AbortTransaction()

--- a/Sources/STOMPNIO/Subscriptions/STOMPClient+subscribe.swift
+++ b/Sources/STOMPNIO/Subscriptions/STOMPClient+subscribe.swift
@@ -1,0 +1,54 @@
+extension STOMPClient {
+    /// Run operation with the STOMP subscription connection
+    ///
+    /// - Parameter operation: Closure to run with subscription connection
+    @inlinable
+    func withSubscriptionConnection<Value>(
+        _ operation: (STOMPConnection) async throws -> Value
+    ) async throws -> Value {
+        let id = self.subscriptionConnectionIDGenerator.next()
+
+        let connection = try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (cont: CheckedContinuation<STOMPConnection, Error>) in
+                self.leaseSubscriptionConnection(id: id, request: cont)
+            }
+        } onCancel: {
+            self.cancelSubscriptionConnection(id: id)
+        }
+
+        defer { self.releaseSubscriptionConnection(id: id) }
+        return try await operation(connection)
+    }
+
+    /// Subscribe to a destination.
+    /// All messages received from the subscription will be acknowledged automatically.
+    /// A single connection is used for all subscriptions.
+    ///
+    /// The subscription is automatically unsubscribed when the `process` closure returns or throws.
+    ///
+    /// - Parameters:
+    ///   - destination: The destination to subscribe to
+    ///   - ackMode: The acknowledgment mode for the subscription
+    ///   - subscribeHeaders: Additional user defined headers to include in the `SUBSCRIBE` frame
+    ///   - unsubscribeHeaders: Additional user defined headers to include in the `UNSUBSCRIBE` frame
+    ///   - process: Closure where messages received from the subscription are processed.
+    ///     The closure receives a ``STOMPSubscription`` `AsyncSequence` to listen for messages.
+    @inlinable
+    public func subscribe<Value>(
+        to destination: String,
+        ackMode: STOMPSubscription.AckMode = .auto,
+        subscribeHeaders: STOMPHeaders = [:],
+        unsubscribeHeaders: STOMPHeaders = [:],
+        process: (STOMPSubscription) async throws -> Value
+    ) async throws -> Value {
+        try await self.withSubscriptionConnection { connection in
+            try await connection.subscribe(
+                to: destination,
+                ackMode: ackMode,
+                subscribeHeaders: subscribeHeaders,
+                unsubscribeHeaders: unsubscribeHeaders,
+                process: process
+            )
+        }
+    }
+}

--- a/Sources/STOMPNIO/Subscriptions/SubscriptionConnectionStateMachine.swift
+++ b/Sources/STOMPNIO/Subscriptions/SubscriptionConnectionStateMachine.swift
@@ -1,0 +1,331 @@
+import Logging
+import Synchronization
+
+extension STOMPClient {
+    @usableFromInline
+    func leaseSubscriptionConnection(id: Int, request: CheckedContinuation<STOMPConnection, any Error>) {
+        self.logger.trace("Get subscription connection", metadata: ["stomp_subscription_connection_id": .stringConvertible(id)])
+        enum LeaseAction {
+            case cancel
+            case action(ConnectionStateMachine.GetAction)
+        }
+        let action: LeaseAction = self.subscriptionConnectionStateMachine.withLock { stateMachine in
+            if Task.isCancelled {
+                return .cancel
+            }
+            return .action(stateMachine.get(id: id, request: request))
+        }
+        switch action {
+        case .cancel:
+            request.resume(throwing: CancellationError())
+        case .action(let getAction):
+            switch getAction {
+            case .startAcquire(let leaseID):
+                self.queueAction(.leaseSubscriptionConnection(leaseID: leaseID))
+            case .completeRequest(let connection):
+                request.resume(returning: connection)
+            case .doNothing:
+                break
+            }
+        }
+    }
+
+    func acquiredSubscriptionConnection(leaseID: Int, connection: STOMPConnection, releaseContinuation: CheckedContinuation<Void, Never>) {
+        let action = self.subscriptionConnectionStateMachine.withLock { stateMachine in
+            stateMachine.acquired(leaseID: leaseID, value: connection, releaseRequest: releaseContinuation)
+        }
+        switch action {
+        case .yield(let continuations):
+            for cont in continuations {
+                cont.resume(returning: connection)
+            }
+        case .release:
+            releaseContinuation.resume()
+        }
+
+    }
+
+    func errorAcquiringSubscriptionConnection(leaseID: Int, error: any Error) {
+        let action = self.subscriptionConnectionStateMachine.withLock { stateMachine in
+            stateMachine.errorAcquiring(leaseID: leaseID, error: error)
+        }
+        switch action {
+        case .yield(let continuations):
+            for cont in continuations {
+                cont.resume(throwing: error)
+            }
+        case .doNothing:
+            break
+        }
+
+    }
+
+    @usableFromInline
+    func releaseSubscriptionConnection(id: Int) {
+        self.logger.trace("Release subscription connection", metadata: ["stomp_subscription_connection_id": .stringConvertible(id)])
+        let action = self.subscriptionConnectionStateMachine.withLock { stateMachine in
+            stateMachine.release(id: id)
+        }
+        switch action {
+        case .release(let continuation):
+            continuation.resume()
+            self.logger.trace("Released connection for subscriptions")
+        case .doNothing:
+            break
+        }
+
+    }
+
+    @usableFromInline
+    func cancelSubscriptionConnection(id: Int) {
+        self.logger.trace("Cancel subscription connection", metadata: ["stomp_subscription_connection_id": .stringConvertible(id)])
+        let action = self.subscriptionConnectionStateMachine.withLock { stateMachine in
+            stateMachine.cancel(id: id)
+        }
+        switch action {
+        case .cancel(let cont):
+            cont.resume(throwing: CancellationError())
+        case .release(let continuation):
+            continuation.resume()
+            self.logger.trace("Released connection for subscriptions")
+        case .doNothing:
+            break
+        }
+    }
+
+    @usableFromInline
+    func shutdownSubscriptionConnection() {
+        self.logger.trace("Shutdown subscription connection")
+        let action = self.subscriptionConnectionStateMachine.withLock { stateMachine in
+            stateMachine.shutdown()
+        }
+        switch action {
+        case .yield(let continuations):
+            for cont in continuations {
+                cont.resume(throwing: STOMPClientError.connectionClosing)
+            }
+        case .release(let continuation):
+            continuation.resume()
+            self.logger.trace("Released connection for subscriptions")
+        case .doNothing:
+            break
+        }
+    }
+}
+
+/// StateMachine for acquiring Subscription Connection.
+@usableFromInline
+struct SubscriptionConnectionStateMachine<Value, Request, ReleaseRequest>: ~Copyable {
+    enum State: ~Copyable {
+        /// We have no connection
+        case uninitialized(nextLeaseID: Int)
+        /// We are acquiring a connection
+        case acquiring(leaseID: Int, waiters: [Int: Request])
+        /// We have a connection
+        case acquired(AcquiredState)
+        /// Connection is shutdown
+        case shutdown
+
+        struct AcquiredState {
+            var leaseID: Int
+            var value: Value
+            var requestIDs: Set<Int>
+            var releaseRequest: ReleaseRequest
+        }
+    }
+    var state: State
+
+    init() {
+        self.state = .uninitialized(nextLeaseID: 0)
+    }
+
+    init(state: consuming State) {
+        self.state = state
+    }
+
+    enum GetAction {
+        case startAcquire(Int)
+        case doNothing
+        case completeRequest(Value)
+    }
+
+    mutating func get(id: Int, request: Request) -> GetAction {
+        switch consume self.state {
+        case .uninitialized(let leaseID):
+            self = .acquiring(leaseID: leaseID, waiters: [id: request])
+            return .startAcquire(leaseID)
+        case .acquiring(let leaseID, var waiters):
+            waiters[id] = request
+            self = .acquiring(leaseID: leaseID, waiters: waiters)
+            return .doNothing
+        case .acquired(var state):
+            state.requestIDs.insert(id)
+            self = .acquired(state)
+            return .completeRequest(state.value)
+        case .shutdown:
+            preconditionFailure("Cannot get subscription connection when shutdown")
+        }
+    }
+
+    enum CancelAction {
+        case cancel(Request)
+        case release(ReleaseRequest)
+        case doNothing
+    }
+
+    mutating func cancel(id: Int) -> CancelAction {
+        switch consume self.state {
+        case .uninitialized(let leaseID):
+            self = .uninitialized(nextLeaseID: leaseID)
+            return .doNothing
+        case .acquiring(let leaseID, var waiters):
+            guard let continuation = waiters.removeValue(forKey: id) else {
+                self = .acquiring(leaseID: leaseID, waiters: waiters)
+                return .doNothing
+            }
+            if waiters.isEmpty {
+                self = .uninitialized(nextLeaseID: leaseID + 1)
+            } else {
+                self = .acquiring(leaseID: leaseID, waiters: waiters)
+            }
+            return .cancel(continuation)
+        case .acquired(var state):
+            state.requestIDs.remove(id)
+            if state.requestIDs.isEmpty {
+                self = .uninitialized(nextLeaseID: state.leaseID + 1)
+                return .release(state.releaseRequest)
+            } else {
+                self = .acquired(state)
+                return .doNothing
+            }
+        case .shutdown:
+            self = .shutdown
+            return .doNothing
+        }
+    }
+
+    enum AcquiredAction {
+        case yield([Request])
+        case release
+    }
+
+    mutating func acquired(leaseID: Int, value: Value, releaseRequest: ReleaseRequest) -> AcquiredAction {
+        switch consume self.state {
+        case .uninitialized(let leaseID):
+            self = .uninitialized(nextLeaseID: leaseID)
+            return .release
+        case .acquiring(let storedLeaseID, let waiters):
+            if storedLeaseID != leaseID {
+                self = .acquiring(leaseID: storedLeaseID, waiters: waiters)
+                return .release
+            }
+            let continuations = waiters.values
+            self = .acquired(.init(leaseID: leaseID, value: value, requestIDs: .init(waiters.keys), releaseRequest: releaseRequest))
+            return .yield(.init(continuations))
+        case .acquired(let state):
+            if state.leaseID != leaseID {
+                self = .acquired(state)
+                return .release
+            } else {
+                preconditionFailure("Acquired connection twice")
+            }
+        case .shutdown:
+            self = .shutdown
+            return .release
+        }
+    }
+
+    enum ErrorAcquiringAction {
+        case yield([Request])
+        case doNothing
+    }
+
+    mutating func errorAcquiring(leaseID: Int, error: any Error) -> ErrorAcquiringAction {
+        switch consume self.state {
+        case .uninitialized(let leaseID):
+            self = .uninitialized(nextLeaseID: leaseID)
+            return .doNothing
+        case .acquiring(let storedLeaseID, let waiters):
+            if storedLeaseID != leaseID {
+                self = .acquiring(leaseID: storedLeaseID, waiters: waiters)
+                return .doNothing
+            }
+            let continuations = waiters.values
+            self = .uninitialized(nextLeaseID: leaseID + 1)
+            return .yield(.init(continuations))
+        case .acquired(let state):
+            if state.leaseID != leaseID {
+                self = .acquired(state)
+                return .doNothing
+            } else {
+                preconditionFailure("Error acquiring connection we already have")
+            }
+        case .shutdown:
+            self = .shutdown
+            return .doNothing
+        }
+    }
+
+    enum ReleaseAction {
+        case release(ReleaseRequest)
+        case doNothing
+    }
+
+    mutating func release(id: Int) -> ReleaseAction {
+        switch consume self.state {
+        case .uninitialized:
+            preconditionFailure("Cannot release connection when in an uninitialized state")
+        case .acquiring:
+            preconditionFailure("Cannot release connection while acquiring a new connection")
+        case .acquired(var state):
+            state.requestIDs.remove(id)
+            if state.requestIDs.isEmpty {
+                self = .uninitialized(nextLeaseID: state.leaseID + 1)
+                return .release(state.releaseRequest)
+            } else {
+                self = .acquired(state)
+                return .doNothing
+            }
+        case .shutdown:
+            self = .shutdown
+            return .doNothing
+        }
+    }
+
+    enum ShutdownAction {
+        case yield([Request])
+        case release(ReleaseRequest)
+        case doNothing
+    }
+
+    mutating func shutdown() -> ShutdownAction {
+        switch consume self.state {
+        case .uninitialized(let leaseID):
+            self = .uninitialized(nextLeaseID: leaseID)
+            return .doNothing
+        case .acquiring(let storedLeaseID, let waiters):
+            self = .uninitialized(nextLeaseID: storedLeaseID + 1)
+            return .yield(.init(waiters.values))
+        case .acquired(let state):
+            self = .uninitialized(nextLeaseID: state.leaseID + 1)
+            return .release(state.releaseRequest)
+        case .shutdown:
+            self = .shutdown
+            return .doNothing
+        }
+    }
+
+    func isEmpty() -> Bool {
+        switch self.state {
+        case .uninitialized: true
+        case .acquiring: false
+        case .acquired: false
+        case .shutdown: true
+        }
+    }
+
+    static private func uninitialized(nextLeaseID: Int) -> Self { .init(state: .uninitialized(nextLeaseID: nextLeaseID)) }
+    static private func acquiring(leaseID: Int, waiters: [Int: Request]) -> Self { .init(state: .acquiring(leaseID: leaseID, waiters: waiters)) }
+    static private func acquired(_ state: State.AcquiredState) -> Self { .init(state: .acquired(state)) }
+    static private var shutdown: Self { .init(state: .shutdown) }
+}

--- a/Tests/STOMPNIOTests/STOMPClientTests.swift
+++ b/Tests/STOMPNIOTests/STOMPClientTests.swift
@@ -30,15 +30,13 @@ struct STOMPClientTests {
 
         try await withThrowingTaskGroup { group in
             group.addTask {
-                try await client.withConnection { connection in
-                    try await connection.subscribe(
-                        to: "/queue/stomp-client-\(ackMode)-\(webSocket == nil ? "tcp" : "websocket")",
-                        ackMode: ackMode
-                    ) { subscription in
-                        for try await frame in subscription {
-                            #expect(String(buffer: frame.body) == "Hello, STOMPClient!")
-                            return
-                        }
+                try await client.subscribe(
+                    to: "/queue/stomp-client-\(ackMode)-\(webSocket == nil ? "tcp" : "websocket")",
+                    ackMode: ackMode
+                ) { subscription in
+                    for try await frame in subscription {
+                        #expect(String(buffer: frame.body) == "Hello, STOMPClient!")
+                        return
                     }
                 }
             }
@@ -68,17 +66,15 @@ struct STOMPClientTests {
 
         try await withThrowingTaskGroup { group in
             group.addTask {
-                try await client.withConnection { connection in
-                    try await connection.subscribe(
-                        to: "/queue/client-large-payload-\(ackMode)-\(webSocket == nil ? "tcp" : "websocket")",
-                        ackMode: ackMode
-                    ) { subscription in
-                        for try await frame in subscription {
-                            var buffer = frame.body
-                            let data = buffer.readData(length: buffer.readableBytes)
-                            #expect(data == payloadData)
-                            return
-                        }
+                try await client.subscribe(
+                    to: "/queue/client-large-payload-\(ackMode)-\(webSocket == nil ? "tcp" : "websocket")",
+                    ackMode: ackMode
+                ) { subscription in
+                    for try await frame in subscription {
+                        var buffer = frame.body
+                        let data = buffer.readData(length: buffer.readableBytes)
+                        #expect(data == payloadData)
+                        return
                     }
                 }
             }

--- a/Tests/STOMPNIOTests/SubscriptionConnectionManagerTests.swift
+++ b/Tests/STOMPNIOTests/SubscriptionConnectionManagerTests.swift
@@ -1,0 +1,199 @@
+import Foundation
+import Logging
+import NIOEmbedded
+import Synchronization
+import Testing
+
+@testable import STOMPNIO
+
+@Suite("SubscriptionConnectionManager Tests")
+struct SubscriptionConnectionManagerTests {
+    struct StateMachine {
+        @Test
+        func testAcquireRelease() {
+            var stateMachine = SubscriptionConnectionStateMachine<String, Int, Int>()
+            let action1 = stateMachine.get(id: 0, request: 10)
+            let action2 = stateMachine.acquired(leaseID: 0, value: "Connection", releaseRequest: 100)
+            let action3 = stateMachine.release(id: 0)
+            #expect(action1 == .startAcquire(0))
+            #expect(action2 == .yield([10]))
+            #expect(action3 == .release(100))
+        }
+
+        @Test
+        func testAcquireReleaseTwice() {
+            var stateMachine = SubscriptionConnectionStateMachine<String, Int, Int>()
+            do {
+                let action1 = stateMachine.get(id: 0, request: 10)
+                let action2 = stateMachine.acquired(leaseID: 0, value: "Connection", releaseRequest: 100)
+                let action3 = stateMachine.release(id: 0)
+                #expect(action1 == .startAcquire(0))
+                #expect(action2 == .yield([10]))
+                #expect(action3 == .release(100))
+            }
+            do {
+                let action1 = stateMachine.get(id: 1, request: 11)
+                let action2 = stateMachine.acquired(leaseID: 1, value: "Connection", releaseRequest: 101)
+                let action3 = stateMachine.release(id: 1)
+                #expect(action1 == .startAcquire(1))
+                #expect(action2 == .yield([11]))
+                #expect(action3 == .release(101))
+            }
+        }
+
+        @Test
+        func testConcurrentAcquireRelease() {
+            var stateMachine = SubscriptionConnectionStateMachine<String, Int, Int>()
+            let action1 = stateMachine.get(id: 0, request: 10)
+            let action2 = stateMachine.get(id: 1, request: 11)
+            let action3 = stateMachine.acquired(leaseID: 0, value: "Connection", releaseRequest: 100)
+            let action4 = stateMachine.release(id: 1)
+            let action5 = stateMachine.release(id: 0)
+            #expect(action1 == .startAcquire(0))
+            #expect(action2 == .doNothing)
+            #expect(action3 == .yield([10, 11]))
+            #expect(action4 == .doNothing)
+            #expect(action5 == .release(100))
+        }
+
+        @Test
+        func testGetAfterAcquire() {
+            do {
+                var stateMachine = SubscriptionConnectionStateMachine<String, Int, Int>()
+                let action1 = stateMachine.get(id: 0, request: 10)
+                let action2 = stateMachine.acquired(leaseID: 0, value: "Connection", releaseRequest: 100)
+                let action3 = stateMachine.get(id: 1, request: 11)
+                let action4 = stateMachine.release(id: 1)
+                let action5 = stateMachine.release(id: 0)
+                #expect(action1 == .startAcquire(0))
+                #expect(action2 == .yield([10]))
+                #expect(action3 == .completeRequest("Connection"))
+                #expect(action4 == .doNothing)
+                #expect(action5 == .release(100))
+            }
+            do {
+                var stateMachine = SubscriptionConnectionStateMachine<String, Int, Int>()
+                let action1 = stateMachine.get(id: 0, request: 10)
+                let action2 = stateMachine.acquired(leaseID: 0, value: "Connection", releaseRequest: 100)
+                let action3 = stateMachine.get(id: 1, request: 11)
+                let action4 = stateMachine.release(id: 0)
+                let action5 = stateMachine.release(id: 1)
+                #expect(action1 == .startAcquire(0))
+                #expect(action2 == .yield([10]))
+                #expect(action3 == .completeRequest("Connection"))
+                #expect(action4 == .doNothing)
+                #expect(action5 == .release(100))
+            }
+        }
+
+        @Test
+        func testCancelWhileAcquiring() {
+            var stateMachine = SubscriptionConnectionStateMachine<String, Int, Int>()
+            let action1 = stateMachine.get(id: 0, request: 10)
+            let action2 = stateMachine.cancel(id: 0)
+            let action3 = stateMachine.acquired(leaseID: 0, value: "Connection", releaseRequest: 100)
+            #expect(action1 == .startAcquire(0))
+            #expect(action2 == .cancel(10))
+            #expect(action3 == .release)
+        }
+
+        @Test
+        func testCancelAfterAcquiring() {
+            var stateMachine = SubscriptionConnectionStateMachine<String, Int, Int>()
+            let action1 = stateMachine.get(id: 0, request: 10)
+            let action2 = stateMachine.acquired(leaseID: 0, value: "Connection", releaseRequest: 100)
+            let action3 = stateMachine.cancel(id: 0)
+            #expect(action1 == .startAcquire(0))
+            #expect(action2 == .yield([10]))
+            #expect(action3 == .release(100))
+        }
+
+        @Test
+        func testCancelWhileMulitpleAcquiring() {
+            var stateMachine = SubscriptionConnectionStateMachine<String, Int, Int>()
+            let action1 = stateMachine.get(id: 0, request: 10)
+            let action2 = stateMachine.get(id: 1, request: 11)
+            let action3 = stateMachine.cancel(id: 0)
+            let action4 = stateMachine.acquired(leaseID: 0, value: "Connection", releaseRequest: 100)
+            let action5 = stateMachine.release(id: 1)
+            #expect(action1 == .startAcquire(0))
+            #expect(action2 == .doNothing)
+            #expect(action3 == .cancel(10))
+            #expect(action4 == .yield([11]))
+            #expect(action5 == .release(100))
+        }
+
+        @Test
+        func testAcquireAfterCancel() {
+            var stateMachine = SubscriptionConnectionStateMachine<String, Int, Int>()
+            let action1 = stateMachine.get(id: 0, request: 10)
+            let action2 = stateMachine.cancel(id: 0)
+            let action3 = stateMachine.acquired(leaseID: 0, value: "Connection", releaseRequest: 100)
+            let action4 = stateMachine.get(id: 1, request: 11)
+            let action5 = stateMachine.acquired(leaseID: 1, value: "Connection", releaseRequest: 101)
+            let action6 = stateMachine.release(id: 1)
+            #expect(action1 == .startAcquire(0))
+            #expect(action2 == .cancel(10))
+            #expect(action3 == .release)
+            #expect(action4 == .startAcquire(1))
+            #expect(action5 == .yield([11]))
+            #expect(action6 == .release(101))
+        }
+    }
+}
+
+extension SubscriptionConnectionStateMachine.GetAction: Equatable where Value: Equatable, Request: Equatable {
+    static func == (_ lhs: Self, _ rhs: Self) -> Bool {
+        switch (lhs, rhs) {
+        case (.startAcquire(let lhs), .startAcquire(let rhs)):
+            lhs == rhs
+        case (.doNothing, .doNothing):
+            true
+        case (.completeRequest(let lhs), .completeRequest(let rhs)):
+            lhs == rhs
+        default:
+            false
+        }
+    }
+}
+
+extension SubscriptionConnectionStateMachine.AcquiredAction: Equatable where Value: Equatable, Request: Equatable & Comparable {
+    static func == (_ lhs: Self, _ rhs: Self) -> Bool {
+        switch (lhs, rhs) {
+        case (.yield(let lhs), .yield(let rhs)):
+            lhs.sorted() == rhs.sorted()
+        case (.release, .release):
+            true
+        default:
+            false
+        }
+    }
+}
+
+extension SubscriptionConnectionStateMachine.CancelAction: Equatable where Value: Equatable, Request: Equatable, ReleaseRequest: Equatable {
+    static func == (_ lhs: Self, _ rhs: Self) -> Bool {
+        switch (lhs, rhs) {
+        case (.doNothing, .doNothing):
+            true
+        case (.cancel(let lhs), .cancel(let rhs)):
+            lhs == rhs
+        case (.release(let lhs), .release(let rhs)):
+            lhs == rhs
+        default:
+            false
+        }
+    }
+}
+
+extension SubscriptionConnectionStateMachine.ReleaseAction: Equatable where Value: Equatable, Request: Equatable, ReleaseRequest: Equatable {
+    static func == (_ lhs: Self, _ rhs: Self) -> Bool {
+        switch (lhs, rhs) {
+        case (.doNothing, .doNothing):
+            true
+        case (.release(let lhs), .release(let rhs)):
+            lhs == rhs
+        default:
+            false
+        }
+    }
+}


### PR DESCRIPTION
- Add a state machine for allocating a single connection to subscriptions for `STOMPClient`.
- The subscription connection is leased in a background process.